### PR TITLE
NO-ISSUE: fix(jira): preserve issue key during rebase

### DIFF
--- a/pre_commit_hooks/add_jira_issue_key_to_commit_msg.sh
+++ b/pre_commit_hooks/add_jira_issue_key_to_commit_msg.sh
@@ -41,7 +41,25 @@ while true; do
     esac
 done
 
-BRANCH_NAME=$(git symbolic-ref --short HEAD 2>/dev/null || echo "unknown")
+get_branch_name() {
+    if BRANCH_NAME=$(git symbolic-ref --quiet --short HEAD 2>/dev/null); then
+        echo "$BRANCH_NAME"
+        return
+    fi
+
+    for REBASE_HEAD_NAME in \
+        "$(git rev-parse --git-path rebase-merge/head-name)" \
+        "$(git rev-parse --git-path rebase-apply/head-name)"; do
+        if [ -f "$REBASE_HEAD_NAME" ]; then
+            sed 's#^refs/heads/##' "$REBASE_HEAD_NAME"
+            return
+        fi
+    done
+
+    echo "unknown"
+}
+
+BRANCH_NAME=$(get_branch_name)
 COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
 
 for PROJECT_KEY in $PROJECT_KEYS; do

--- a/test/test_add_jira_issue_key_to_commit_msg.py
+++ b/test/test_add_jira_issue_key_to_commit_msg.py
@@ -106,3 +106,51 @@ def test_jira_hook(git_repo, branch, original_msg, expected_msg):
 
     final_msg = msg_file.read_text().strip()
     assert final_msg == expected_msg.strip(), f"Stderr: {result.stderr}"
+
+
+def test_jira_hook_uses_rebase_branch_name_when_head_is_detached(git_repo):
+    subprocess.run(
+        ["git", "checkout", "-b", "MAF-1234-feature"],
+        cwd=git_repo,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        ["git", "checkout", "--detach"],
+        cwd=git_repo,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    git_dir = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=git_repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+    ).stdout.strip()
+    rebase_merge_dir = git_repo / git_dir / "rebase-merge"
+    rebase_merge_dir.mkdir(parents=True)
+    (rebase_merge_dir / "head-name").write_text("refs/heads/MAF-1234-feature")
+
+    msg_file = git_repo / "COMMIT_EDITMSG"
+    msg_file.write_text("MAF-1234: feat: keep me")
+
+    args = [str(HOOK_SCRIPT), str(msg_file), "-k", "MAF", "--enable-no-issue"]
+    result = subprocess.run(
+        args,
+        cwd=git_repo,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+    )
+
+    if result.returncode != 0:
+        pytest.fail(f"Hook failed with {result.returncode}\nStderr: {result.stderr}")
+
+    final_msg = msg_file.read_text().strip()
+    assert final_msg == "MAF-1234: feat: keep me", f"Stderr: {result.stderr}"


### PR DESCRIPTION
## Summary
- resolve the current branch name from Git rebase metadata when `HEAD` is detached
- preserve Jira-prefixed commit messages during rebase instead of rewriting them to `NO-ISSUE`
- add a regression test covering the detached-`HEAD` rebase path

## Why
During `git rebase`, the prepare-commit-msg hook can run while `HEAD` is detached. The hook previously relied only on `git symbolic-ref --short HEAD`, so branch detection failed and an existing `MAF-1234:` prefix was replaced with `NO-ISSUE:`.

## Validation
- `mise run test`
